### PR TITLE
해시태그 CRUD

### DIFF
--- a/src/main/java/towssome/server/entity/HashTag.java
+++ b/src/main/java/towssome/server/entity/HashTag.java
@@ -1,12 +1,26 @@
 package towssome.server.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class HashTag {
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "hashtag_id")
     private Long id;
     private String name;
+    @Setter
     private Long count;
+
+    public HashTag(String name, Long count) {
+        this.name = name;
+        this.count = count;
+    }
+
 }

--- a/src/main/java/towssome/server/entity/HashtagClassification.java
+++ b/src/main/java/towssome/server/entity/HashtagClassification.java
@@ -1,14 +1,17 @@
 package towssome.server.entity;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class HashtagClassification {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(name = "class_id")
+    @Column(name = "hashtag_classification_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -18,4 +21,9 @@ public class HashtagClassification {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id")
     private ReviewPost reviewPost;
+
+    public HashtagClassification(HashTag hashTag, ReviewPost reviewPost) {
+        this.hashTag = hashTag;
+        this.reviewPost = reviewPost;
+    }
 }

--- a/src/main/java/towssome/server/repository/HashTagRepository.java
+++ b/src/main/java/towssome/server/repository/HashTagRepository.java
@@ -4,4 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import towssome.server.entity.HashTag;
 
 public interface HashTagRepository extends JpaRepository<HashTag,Long> {
+
+    boolean existsByName(String name);
+
+    HashTag findByName(String name);
+
 }

--- a/src/main/java/towssome/server/repository/HashtagClassificationRepository.java
+++ b/src/main/java/towssome/server/repository/HashtagClassificationRepository.java
@@ -1,0 +1,14 @@
+package towssome.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import towssome.server.entity.HashtagClassification;
+import towssome.server.entity.ReviewPost;
+
+import java.util.List;
+
+public interface HashtagClassificationRepository extends JpaRepository<HashtagClassification,Long>{
+
+    List<HashtagClassification> findAllByReviewPost(ReviewPost reviewPost);
+
+
+}

--- a/src/main/java/towssome/server/service/HashtagService.java
+++ b/src/main/java/towssome/server/service/HashtagService.java
@@ -21,7 +21,7 @@ public class HashtagService {
 
     /**
      * koBert 를 통해 추출한 문자열을 인자로 받습니다. 해당 문자열이 해시태그로 저장되어 있으면 1증가
-     * 없으면 해시태그를 새로 생성합니다
+     * 없으면 해시태그를 count 를 1로 설정하고 새로 생성합니다
      * @param list
      * @param reviewPost
      */

--- a/src/main/java/towssome/server/service/HashtagService.java
+++ b/src/main/java/towssome/server/service/HashtagService.java
@@ -1,0 +1,82 @@
+package towssome.server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import towssome.server.entity.HashTag;
+import towssome.server.entity.HashtagClassification;
+import towssome.server.entity.ReviewPost;
+import towssome.server.repository.HashTagRepository;
+import towssome.server.repository.HashtagClassificationRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HashtagService {
+
+    private final HashTagRepository hashtagRepository;
+    private final HashtagClassificationRepository hashtagClassificationRepository;
+
+    /**
+     * koBert 를 통해 추출한 문자열을 인자로 받습니다. 해당 문자열이 해시태그로 저장되어 있으면 1증가
+     * 없으면 해시태그를 새로 생성합니다
+     * @param list
+     * @param reviewPost
+     */
+    public void createHashtag(List<String> list, ReviewPost reviewPost){
+        ArrayList<HashTag> forReviewPostHashtag = new ArrayList<>();
+        for (String s : list) {
+            if(!hashtagRepository.existsByName(s)){
+                HashTag save = hashtagRepository.save(new HashTag(
+                        s,
+                        1L
+                ));
+                forReviewPostHashtag.add(save);
+            }else {
+                HashTag find = hashtagRepository.findByName(s);
+                find.setCount(find.getCount()+1);
+                forReviewPostHashtag.add(find);
+            }
+        }
+
+        for (HashTag hashTag : forReviewPostHashtag) {
+            hashtagClassificationRepository.save(new HashtagClassification(
+                    hashTag,
+                    reviewPost
+            ));
+        }
+    }
+
+    /**
+     * 리뷰글에 담긴 해시태그를 삭제합니다. 해시태그와 리뷰글의 다대다 테이블의 컬럼도 삭제합니다
+     * 해시태그 테이블은 실제로 삭제되는게 아니라 0이 되어도 다시 사용될 여지가 있기에 count 만 줄입니다.
+     * @param reviewPost
+     */
+    @Transactional
+    public void deleteHashtagByReviewPost(ReviewPost reviewPost){
+        List<HashtagClassification> byReviewPost = hashtagClassificationRepository.findAllByReviewPost(reviewPost);
+        for (HashtagClassification hashtagClassification : byReviewPost) {
+            HashTag hashTag = hashtagClassification.getHashTag();
+            hashTag.setCount(hashTag.getCount()-1);
+        }
+        hashtagClassificationRepository.deleteAll(byReviewPost);
+    }
+
+    /**
+     * 리뷰글에 담긴 해시태그를 찾아 반환합니다
+     * @param reviewPost
+     * @return
+     */
+    @Transactional
+    public List<HashTag> findAllByReviewPost(ReviewPost reviewPost){
+        List<HashtagClassification> allByReviewPost = hashtagClassificationRepository.findAllByReviewPost(reviewPost);
+        List<HashTag> result = new ArrayList<>();
+        for (HashtagClassification hashtagClassification : allByReviewPost) {
+            result.add(hashtagClassification.getHashTag());
+        }
+        return result;
+    }
+
+}


### PR DESCRIPTION
#46 
해시태그 생성 기능
인자를 koBert를 통해 추출된 문자열 리스트를 받습니다.
-> 문자열 리스트가 될지 아직 몰라 수정될 수 있습니다

해시태그 삭제 기능
리뷰글이 삭제될 때 이 메서드를 먼저 호출해야 합니다.
ReviewPostService 의 deleteReview를 사용할 때 이 메서드를 사용하도록 수정하였습니다

해시태그 조회 기능
리뷰글 객체를 인자로 받아 해당 리뷰글이 가진 모든 해시태그를 반환합니다