### PR TITLE
comment 조회 무한스크롤 변경

### DIFF
--- a/src/main/java/towssome/server/controller/CommentController.java
+++ b/src/main/java/towssome/server/controller/CommentController.java
@@ -8,8 +8,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+import towssome.server.advice.MemberAdvice;
 import towssome.server.dto.*;
 import towssome.server.entity.Comment;
+import towssome.server.entity.Member;
+import towssome.server.service.CommentLikeService;
 import towssome.server.service.CommentService;
 
 import java.io.IOException;
@@ -21,6 +24,8 @@ import java.util.ArrayList;
 @RequestMapping("/review")
 public class CommentController {
     private final CommentService commentService;
+    private final CommentLikeService commentLikeService;
+    private final MemberAdvice memberAdvice;
     private static final int DEFAULT_SIZE = 20;
 
     @PostMapping("/{reviewId}/create")
@@ -61,5 +66,13 @@ public class CommentController {
                                                 @RequestParam(value = "size", required = false) Integer size){
         if(size == null) size = DEFAULT_SIZE;
         return commentService.getCommentPageByReviewId(reviewId, cursorId, sort, PageRequest.of(0,size));
+    }
+
+    @PostMapping("/{reviewId}/commentLike/{commentId}")
+    public ResponseEntity<?> changeLike(@PathVariable Long reviewId, @PathVariable Long commentId){
+        Member user = memberAdvice.findJwtMember();
+        Comment comment = commentService.getComment(commentId);
+        commentLikeService.likeProcess(user, comment);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/towssome/server/controller/CommentController.java
+++ b/src/main/java/towssome/server/controller/CommentController.java
@@ -3,13 +3,12 @@ package towssome.server.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
-import towssome.server.dto.CommentReq;
-import towssome.server.dto.CommentListRes;
-import towssome.server.dto.CommentUpdateReq;
+import towssome.server.dto.*;
 import towssome.server.entity.Comment;
 import towssome.server.service.CommentService;
 
@@ -56,25 +55,11 @@ public class CommentController {
     }
 
     @GetMapping("/{reviewId}/comments")
-    public PageResult<CommentListRes> getCommentList(@PathVariable Long reviewId, @RequestParam String sort, @RequestParam int page){
-        Page<Comment> commentList = commentService.getComments(sort, reviewId, page-1, DEFAULT_SIZE);
-        ArrayList<CommentListRes> commentListRes = new ArrayList<>();
-        for(Comment comment: commentList.getContent()){
-            commentListRes.add(new CommentListRes(
-                    comment.getId(),
-                    comment.getBody(),
-                    comment.getCreateDate(),
-                    comment.getLastModifiedDate(),
-                    comment.getMember().getId(),
-                    comment.getReviewPost().getId()
-            ));
-        }
-        return new PageResult<>(
-                commentListRes,
-                commentList.getTotalElements(),
-                commentList.getTotalPages(),
-                commentList.getNumber()+1,
-                DEFAULT_SIZE
-        );
+    public CursorResult<CommentRes> getComments(@PathVariable Long reviewId,
+                                                @RequestParam(value = "cursorId", required = false) Long cursorId,
+                                                @RequestParam(value = "sort", defaultValue = "asc", required = false) String sort,
+                                                @RequestParam(value = "size", required = false) Integer size){
+        if(size == null) size = DEFAULT_SIZE;
+        return commentService.getCommentPageByReviewId(reviewId, cursorId, sort, PageRequest.of(0,size));
     }
 }

--- a/src/main/java/towssome/server/controller/ReviewController.java
+++ b/src/main/java/towssome/server/controller/ReviewController.java
@@ -144,33 +144,12 @@ public class ReviewController {
 
     /** 해시태그 검색 */
     @GetMapping("/search")
-    public PageResult<ReviewPostRes> keywordSearch(@RequestPart(value="keyword") String keyword,@RequestParam String sort, @RequestParam int page){
-        Page<ReviewPost> result = hashtagClassificationService.getReviewPostByHashtag(keyword, sort, page-1, PAGE_SIZE);
-        ArrayList<ReviewPostRes> reviewPostListRes = new ArrayList<>();
-        for(ReviewPost reviewPost: result.getContent()){
-            reviewPostListRes.add(new ReviewPostRes(
-                    reviewPost.getBody(),
-                    reviewPost.getPrice(),
-                    reviewPost.getCreateDate(),
-                    reviewPost.getLastModifiedDate(),
-                    reviewPost.getMember().getId(),
-                    photoService.getPhotoS3Path(reviewPost),
-                    false,
-                    false,
-                    false,
-                    hashtagClassificationService.getHashtags(reviewPost.getId()),
-                    reviewPost.getReviewType(),
-                    reviewPost.getStarPoint(),
-                    reviewPost.getWhereBuy()
-            ));
-        }
-        return new PageResult<>(
-                reviewPostListRes,
-                result.getTotalElements(),
-                result.getTotalPages(),
-                result.getNumber()+1,
-                PAGE_SIZE
-        );
+    public CursorResult<ReviewPostRes> keywordSearch(@RequestParam(value="keyword") String keyword,
+                                                     @RequestParam(value = "cursorId", required = false) Long cursorId,
+                                                     @RequestParam(value = "sort", defaultValue = "desc", required = false) String sort,
+                                                     @RequestParam(value = "size", required = false) Integer size) {
+        if (size == null) size = PAGE_SIZE;
+        return hashtagClassificationService.getReviewPageByHashtag(keyword, cursorId, sort, PageRequest.of(0,size));
     }
 
 }

--- a/src/main/java/towssome/server/controller/ReviewController.java
+++ b/src/main/java/towssome/server/controller/ReviewController.java
@@ -144,7 +144,7 @@ public class ReviewController {
 
     /** 해시태그 검색 */
     @GetMapping("/search")
-    public CursorResult<ReviewPostRes> keywordSearch(@RequestParam(value="keyword") String keyword,
+    public CursorResult<ReviewSimpleRes> keywordSearch(@RequestParam(value="keyword") String keyword,
                                                      @RequestParam(value = "cursorId", required = false) Long cursorId,
                                                      @RequestParam(value = "sort", defaultValue = "desc", required = false) String sort,
                                                      @RequestParam(value = "size", required = false) Integer size) {

--- a/src/main/java/towssome/server/dto/CommentRes.java
+++ b/src/main/java/towssome/server/dto/CommentRes.java
@@ -2,7 +2,7 @@ package towssome.server.dto;
 
 import java.time.LocalDateTime;
 
-public record CommentListRes(
+public record CommentRes(
         Long commentId,
         String body,
         LocalDateTime createDate,

--- a/src/main/java/towssome/server/dto/CommentRes.java
+++ b/src/main/java/towssome/server/dto/CommentRes.java
@@ -8,6 +8,8 @@ public record CommentRes(
         LocalDateTime createDate,
         LocalDateTime lastModifiedDate,
         Long memberId,
-        Long reviewId
+        Long reviewId,
+        Boolean isLiked,
+        Long likeCount
 ) {
 }

--- a/src/main/java/towssome/server/entity/CommentLike.java
+++ b/src/main/java/towssome/server/entity/CommentLike.java
@@ -1,0 +1,28 @@
+package towssome.server.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class CommentLike {
+
+    @Id
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public CommentLike(Member member, Comment comment){
+        this.member = member;
+        this.comment = comment;
+    }
+}
+

--- a/src/main/java/towssome/server/repository/CommentLikeRepository.java
+++ b/src/main/java/towssome/server/repository/CommentLikeRepository.java
@@ -1,0 +1,11 @@
+package towssome.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import towssome.server.entity.CommentLike;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long>,CommentLikeRepositoryCustom {
+    CommentLike findByMemberIdAndCommentId(Long memberId, Long commentId);
+}

--- a/src/main/java/towssome/server/repository/CommentLikeRepositoryCustom.java
+++ b/src/main/java/towssome/server/repository/CommentLikeRepositoryCustom.java
@@ -1,0 +1,5 @@
+package towssome.server.repository;
+
+public interface CommentLikeRepositoryCustom {
+    Long countByCommentId(Long commentId);
+}

--- a/src/main/java/towssome/server/repository/CommentLikeRepositoryImpl.java
+++ b/src/main/java/towssome/server/repository/CommentLikeRepositoryImpl.java
@@ -1,0 +1,24 @@
+package towssome.server.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import towssome.server.entity.CommentLike;
+
+import static towssome.server.entity.QCommentLike.commentLike;
+
+@RequiredArgsConstructor
+@Slf4j
+public class CommentLikeRepositoryImpl implements CommentLikeRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Long countByCommentId(Long commentId) {
+        return queryFactory
+                .select(commentLike.count())
+                .from(commentLike)
+                .where(commentLike.comment.id.eq(commentId))
+                .fetchOne();
+    }
+
+}

--- a/src/main/java/towssome/server/repository/CommentRepositoryCustom.java
+++ b/src/main/java/towssome/server/repository/CommentRepositoryCustom.java
@@ -5,6 +5,6 @@ import org.springframework.data.domain.Pageable;
 import towssome.server.entity.Comment;
 
 public interface CommentRepositoryCustom {
-
-    Page<Comment> findAllByReviewIdOrderBySort(String sort, Long reviewId, Pageable pageable);
+    Page<Comment> findFirstCommentPage(Long reviewId, String sort, Pageable page);
+    Page<Comment> findCommentPageByCursorId(Long reviewId, Long cursorId, String sort, Pageable page);
 }

--- a/src/main/java/towssome/server/repository/HashtagClassificationRepositoryCustom.java
+++ b/src/main/java/towssome/server/repository/HashtagClassificationRepositoryCustom.java
@@ -7,7 +7,7 @@ import towssome.server.entity.ReviewPost;
 import java.util.List;
 
 public interface HashtagClassificationRepositoryCustom {
-    Page<ReviewPost> findReviewsByHashtagOrderBySort(String keyword, String sort, Pageable pageable);
-
+    Page<ReviewPost> findFirstReviewPageByHashtag(String keyword, String sort, Pageable pageable);
+    Page<ReviewPost> findReviewPageByCursorIdAndHashTag(String keyword, Long cursorId, String sort, Pageable pageable);
     List<String> findHashtagsByReviewId(Long reviewId);
 }

--- a/src/main/java/towssome/server/repository/HashtagClassificationRepositoryImpl.java
+++ b/src/main/java/towssome/server/repository/HashtagClassificationRepositoryImpl.java
@@ -84,7 +84,7 @@ public class HashtagClassificationRepositoryImpl implements HashtagClassificatio
         JPAQuery<Long> count = queryFactory
                 .select(hashtagClassification.count())
                 .from(hashtagClassification)
-                .where(hashtagContains(keyword))
+                .where(hashtagContains(keyword),nextReviewId(cursorId,false))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize());
 

--- a/src/main/java/towssome/server/service/CommentLikeService.java
+++ b/src/main/java/towssome/server/service/CommentLikeService.java
@@ -1,0 +1,36 @@
+package towssome.server.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import towssome.server.entity.Comment;
+import towssome.server.entity.CommentLike;
+import towssome.server.entity.Member;
+import towssome.server.repository.CommentLikeRepository;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CommentLikeService {
+    private final CommentLikeRepository commentLikeRepository;
+
+    public Boolean isLikedComment(Member member, Comment comment){
+        CommentLike commentLike = commentLikeRepository.findByMemberIdAndCommentId(member.getId(), comment.getId());
+        if(commentLike == null) return false;
+        else return true;
+    }
+
+    public Long countLike(Comment comment){
+        return commentLikeRepository.countByCommentId(comment.getId());
+    }
+
+    public void likeProcess(Member member, Comment comment){
+        CommentLike commentLike = commentLikeRepository.findByMemberIdAndCommentId(member.getId(), comment.getId());
+        if(commentLike == null){
+            commentLikeRepository.save(new CommentLike(member,comment));
+        }
+        else {
+            commentLikeRepository.delete(commentLike);
+        }
+    }
+}

--- a/src/main/java/towssome/server/service/CommentService.java
+++ b/src/main/java/towssome/server/service/CommentService.java
@@ -4,9 +4,9 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import towssome.server.advice.MemberAdvice;
 import towssome.server.dto.*;
 import towssome.server.entity.Comment;
 import towssome.server.entity.Member;
@@ -15,7 +15,6 @@ import towssome.server.exception.NotFoundCommentException;
 import towssome.server.exception.NotFoundMemberException;
 import towssome.server.exception.NotFoundReviewPostException;
 import towssome.server.repository.CommentRepository;
-import towssome.server.repository.CommentRepositoryImpl;
 import towssome.server.repository.ReviewPostRepository;
 
 import java.util.ArrayList;
@@ -28,6 +27,8 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final ReviewPostRepository reviewPostRepository;
     private final MemberService memberService;
+    private final CommentLikeService commentLikeService;
+    private final MemberAdvice memberAdvice;
 
     public void createComment(CommentReq commentReq, String username) {
         Long reviewId = commentReq.reviewPostId();
@@ -73,7 +74,9 @@ public class CommentService {
                     comment.getCreateDate(),
                     comment.getLastModifiedDate(),
                     comment.getMember().getId(),
-                    comment.getReviewPost().getId()
+                    comment.getReviewPost().getId(),
+                    commentLikeService.isLikedComment(memberAdvice.findJwtMember(),comment),
+                    commentLikeService.countLike(comment)
             ));
         }
         cursorId = comments.isEmpty()?

--- a/src/main/java/towssome/server/service/HashtagClassificationService.java
+++ b/src/main/java/towssome/server/service/HashtagClassificationService.java
@@ -6,9 +6,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import towssome.server.dto.CursorResult;
+import towssome.server.dto.ReviewPostRes;
 import towssome.server.entity.ReviewPost;
 import towssome.server.repository.HashtagClassificationRepository;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -17,11 +20,39 @@ import java.util.List;
 public class HashtagClassificationService {
 
     private final HashtagClassificationRepository hashtagClassificationRepository;
+    private final PhotoService photoService;
+
+    public CursorResult<ReviewPostRes> getReviewPageByHashtag(String keyword, Long cursorId, String sort, Pageable page) {
+        List<ReviewPostRes> reviewPostRes = new ArrayList<>();
+        final Page<ReviewPost> reviewPosts = getReviewPostByHashtag(keyword, cursorId, sort, page);
+        for(ReviewPost review : reviewPosts){
+            reviewPostRes.add(new ReviewPostRes(
+                    review.getBody(),
+                    review.getPrice(),
+                    review.getCreateDate(),
+                    review.getLastModifiedDate(),
+                    review.getMember().getId(),
+                    photoService.getPhotoS3Path(review),
+                    false,
+                    false,
+                    false,
+                    getHashtags(review.getId()),
+                    review.getReviewType(),
+                    review.getStarPoint(),
+                    review.getWhereBuy()
+            ));
+        }
+        cursorId = reviewPosts.isEmpty()?
+                null:reviewPosts.getContent().get(reviewPosts.getContent().size()-1).getId();
+        return new CursorResult<>(reviewPostRes, cursorId, reviewPosts.hasNext());
+    }
+
 
     // 해시태그로 리뷰글 검색
-    public Page<ReviewPost> getReviewPostByHashtag(String keyword, String sort, int page, int size){
-        Pageable pageable = PageRequest.of(page,size);
-        return hashtagClassificationRepository.findReviewsByHashtagOrderBySort(keyword,sort, pageable);
+    public Page<ReviewPost> getReviewPostByHashtag(String keyword, Long cursorId, String sort, Pageable page){
+        return cursorId == null ?
+                hashtagClassificationRepository.findFirstReviewPageByHashtag(keyword, sort, page):
+                hashtagClassificationRepository.findReviewPageByCursorIdAndHashTag(keyword, cursorId, sort, page);
     }
 
     public List<String> getHashtags(Long reviewId) {

--- a/src/main/java/towssome/server/service/HashtagClassificationService.java
+++ b/src/main/java/towssome/server/service/HashtagClassificationService.java
@@ -7,7 +7,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import towssome.server.dto.CursorResult;
+import towssome.server.dto.PhotoInPost;
 import towssome.server.dto.ReviewPostRes;
+import towssome.server.dto.ReviewSimpleRes;
 import towssome.server.entity.ReviewPost;
 import towssome.server.repository.HashtagClassificationRepository;
 
@@ -17,36 +19,37 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class HashtagClassificationService {
+public class HashtagClassificationService{
 
     private final HashtagClassificationRepository hashtagClassificationRepository;
     private final PhotoService photoService;
 
-    public CursorResult<ReviewPostRes> getReviewPageByHashtag(String keyword, Long cursorId, String sort, Pageable page) {
-        List<ReviewPostRes> reviewPostRes = new ArrayList<>();
+    public CursorResult<ReviewSimpleRes> getReviewPageByHashtag(String keyword, Long cursorId, String sort, Pageable page) {
+        List<ReviewSimpleRes> reviewSimpleRes = new ArrayList<>();
         final Page<ReviewPost> reviewPosts = getReviewPostByHashtag(keyword, cursorId, sort, page);
-        for(ReviewPost review : reviewPosts){
-            reviewPostRes.add(new ReviewPostRes(
-                    review.getBody(),
-                    review.getPrice(),
-                    review.getCreateDate(),
-                    review.getLastModifiedDate(),
-                    review.getMember().getId(),
-                    photoService.getPhotoS3Path(review),
-                    false,
-                    false,
-                    false,
-                    getHashtags(review.getId()),
-                    review.getReviewType(),
-                    review.getStarPoint(),
-                    review.getWhereBuy()
+        return getReviewSimpleResCursorResult(reviewSimpleRes, reviewPosts);
+    }
+    private CursorResult<ReviewSimpleRes> getReviewSimpleResCursorResult(List<ReviewSimpleRes> reviewSimpleRes, Page<ReviewPost> reviewPosts) {
+        Long cursorId;
+        for(ReviewPost review : reviewPosts) {
+            List<PhotoInPost> bodyPhotos = photoService.getPhotoS3Path(review);
+            String bodyPhoto = bodyPhotos.isEmpty() ? null : bodyPhotos.get(0).photoPath();
+            String profilePhoto = review.getMember().getProfilePhoto() != null ?
+                    review.getMember().getProfilePhoto().getS3Path() :
+                    null;
+
+            reviewSimpleRes.add(new ReviewSimpleRes(
+                    review.getId(),
+                    profilePhoto,
+                    review.getMember().getNickName(),
+                    bodyPhoto,
+                    getHashtags(review.getId())
             ));
         }
-        cursorId = reviewPosts.isEmpty()?
-                null:reviewPosts.getContent().get(reviewPosts.getContent().size()-1).getId();
-        return new CursorResult<>(reviewPostRes, cursorId, reviewPosts.hasNext());
+        cursorId = reviewPosts.isEmpty() ?
+                null : reviewPosts.getContent().get(reviewPosts.getContent().size() - 1).getId();
+        return new CursorResult<>(reviewSimpleRes, cursorId, reviewPosts.hasNext());
     }
-
 
     // 해시태그로 리뷰글 검색
     public Page<ReviewPost> getReviewPostByHashtag(String keyword, Long cursorId, String sort, Pageable page){


### PR DESCRIPTION
#14  comment 조회가 이전엔 페이지네이션이었는데 무한스크롤로 변경했습니다.

파라미터는
cursorId(지정하면 해당 커서 다음 코멘트)
sort(기본값 asc. 내림차순은 desc입력하고, 다른 텍스트 입력하면 asc로 출력됩니다.)
size(코멘트 조회 개수)