### PR TITLE
빠른 추천하기 추가

### DIFF
--- a/src/main/java/towssome/server/controller/CommentController.java
+++ b/src/main/java/towssome/server/controller/CommentController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,13 +14,10 @@ import towssome.server.advice.MemberAdvice;
 import towssome.server.dto.*;
 import towssome.server.entity.Comment;
 import towssome.server.entity.Member;
-import towssome.server.entity.ReviewPost;
 import towssome.server.service.CommentLikeService;
 import towssome.server.service.CommentService;
-import towssome.server.service.ReviewPostService;
 
 import java.io.IOException;
-import java.util.ArrayList;
 
 @Tag(name = "댓글")
 @RestController
@@ -31,7 +27,6 @@ import java.util.ArrayList;
 public class CommentController {
     private final CommentService commentService;
     private final CommentLikeService commentLikeService;
-    private final ReviewPostService reviewPostService;
     private final MemberAdvice memberAdvice;
     private static final int DEFAULT_SIZE = 20;
 

--- a/src/main/java/towssome/server/controller/QuickRecommendController.java
+++ b/src/main/java/towssome/server/controller/QuickRecommendController.java
@@ -1,0 +1,29 @@
+package towssome.server.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.*;
+import towssome.server.dto.CursorResult;
+import towssome.server.dto.QuickRecommendReq;
+import towssome.server.dto.ReviewSimpleRes;
+import towssome.server.service.HashtagClassificationService;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/recommend")
+public class QuickRecommendController {
+    private static final int DEFAULT_SIZE = 5;
+    private final HashtagClassificationService hashtagClassificationService;
+
+    @PostMapping("/result")
+    public CursorResult<ReviewSimpleRes> QuickRecommend(@RequestBody QuickRecommendReq req,
+                                                        @RequestParam(value = "cursorId", required = false) Long cursorId,
+                                                        @RequestParam(value = "size", required = false) Integer size){
+        if (size == null) size = DEFAULT_SIZE;
+        return hashtagClassificationService.getRecommendPageByHashtag(req, cursorId, "desc", PageRequest.of(0,size));
+    }
+}

--- a/src/main/java/towssome/server/dto/QuickRecommendReq.java
+++ b/src/main/java/towssome/server/dto/QuickRecommendReq.java
@@ -1,0 +1,8 @@
+package towssome.server.dto;
+
+public record QuickRecommendReq(
+        /*String category,*/
+        String ageTag,
+        String interestTag
+) {
+}

--- a/src/main/java/towssome/server/repository/HashtagClassificationRepositoryCustom.java
+++ b/src/main/java/towssome/server/repository/HashtagClassificationRepositoryCustom.java
@@ -2,6 +2,7 @@ package towssome.server.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import towssome.server.dto.QuickRecommendReq;
 import towssome.server.entity.ReviewPost;
 
 import java.util.List;
@@ -10,4 +11,6 @@ public interface HashtagClassificationRepositoryCustom {
     Page<ReviewPost> findFirstReviewPageByHashtag(String keyword, String sort, Pageable pageable);
     Page<ReviewPost> findReviewPageByCursorIdAndHashTag(String keyword, Long cursorId, String sort, Pageable pageable);
     List<String> findHashtagsByReviewId(Long reviewId);
+    Page<ReviewPost> findFirstRecommendPageByHashtag(QuickRecommendReq req, String sort, Pageable pageable);
+    Page<ReviewPost> findRecommendPageByCursorIdAndHashTag(QuickRecommendReq req, Long cursorId, String sort, Pageable pageable);
 }

--- a/src/main/java/towssome/server/repository/HashtagClassificationRepositoryImpl.java
+++ b/src/main/java/towssome/server/repository/HashtagClassificationRepositoryImpl.java
@@ -1,6 +1,8 @@
 package towssome.server.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +10,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
+import towssome.server.dto.QuickRecommendReq;
+import towssome.server.entity.QHashtagClassification;
 import towssome.server.entity.ReviewPost;
 
 import java.util.List;
@@ -23,28 +27,21 @@ public class HashtagClassificationRepositoryImpl implements HashtagClassificatio
 
     @Override
     public Page<ReviewPost> findFirstReviewPageByHashtag(String keyword, String sort, Pageable pageable) {
-        List<ReviewPost> results;
+        JPAQuery<ReviewPost> query = queryFactory
+                .select(hashtagClassification.reviewPost)
+                .from(hashtagClassification)
+                .join(hashtagClassification.hashTag, hashTag)
+                .where(hashtagContains(keyword))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
         if (sort.equalsIgnoreCase("asc")) {
-            results = queryFactory
-                    .select(hashtagClassification.reviewPost)
-                    .from(hashtagClassification)
-                    .join(hashtagClassification.hashTag, hashTag)
-                    .where(hashtagContains(keyword))
-                    .orderBy(reviewPost.id.asc())
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize())
-                    .fetch();
+            query.orderBy(reviewPost.id.asc());
         } else {
-            results = queryFactory
-                    .select(hashtagClassification.reviewPost)
-                    .from(hashtagClassification)
-                    .join(hashtagClassification.hashTag, hashTag)
-                    .where(hashtagContains(keyword))
-                    .orderBy(reviewPost.id.desc())
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize())
-                    .fetch();
+            query.orderBy(reviewPost.id.desc());
         }
+
+        List<ReviewPost> results = query.fetch();
 
         JPAQuery<Long> count = queryFactory
                 .select(hashtagClassification.count())
@@ -58,28 +55,21 @@ public class HashtagClassificationRepositoryImpl implements HashtagClassificatio
 
     @Override
     public Page<ReviewPost> findReviewPageByCursorIdAndHashTag(String keyword, Long cursorId, String sort, Pageable pageable) {
-        List<ReviewPost> results;
+        JPAQuery<ReviewPost> query = queryFactory
+                .select(hashtagClassification.reviewPost)
+                .from(hashtagClassification)
+                .join(hashtagClassification.hashTag, hashTag)
+                .where(hashtagContains(keyword),nextReviewId(cursorId,true))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
         if (sort.equalsIgnoreCase("asc")) {
-            results = queryFactory
-                    .select(hashtagClassification.reviewPost)
-                    .from(hashtagClassification)
-                    .join(hashtagClassification.hashTag, hashTag)
-                    .where(hashtagContains(keyword),nextReviewId(cursorId,true))
-                    .orderBy(reviewPost.id.asc())
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize())
-                    .fetch();
+            query.orderBy(reviewPost.id.asc());
         } else {
-            results = queryFactory
-                    .select(hashtagClassification.reviewPost)
-                    .from(hashtagClassification)
-                    .join(hashtagClassification.hashTag, hashTag)
-                    .where(hashtagContains(keyword),nextReviewId(cursorId,false))
-                    .orderBy(reviewPost.id.desc())
-                    .offset(pageable.getOffset())
-                    .limit(pageable.getPageSize())
-                    .fetch();
+            query.orderBy(reviewPost.id.desc());
         }
+
+        List<ReviewPost> results = query.fetch();
 
         JPAQuery<Long> count = queryFactory
                 .select(hashtagClassification.count())
@@ -100,11 +90,141 @@ public class HashtagClassificationRepositoryImpl implements HashtagClassificatio
                 .fetch();
     }
 
+    @Override
+    public Page<ReviewPost> findFirstRecommendPageByHashtag(QuickRecommendReq req, String sort, Pageable pageable){
+        JPAQuery<ReviewPost> query = queryFactory
+                .select(hashtagClassification.reviewPost)
+                .from(hashtagClassification)
+                .join(hashtagClassification.hashTag, hashTag)
+                .where(hashtagContainsAgeOrInterest(req))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        if (sort.equalsIgnoreCase("asc")) {
+            query.orderBy(reviewPost.id.asc());
+        } else {
+            query.orderBy(reviewPost.id.desc());
+        }
+
+        List<ReviewPost> results = query.fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(hashtagClassification.reviewPost.count())
+                .from(hashtagClassification)
+                .join(hashtagClassification.hashTag, hashTag)
+                .where(hashtagContainsAgeOrInterest(req));
+
+        return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchOne);
+
+    }
+
+    @Override
+    public Page<ReviewPost> findRecommendPageByCursorIdAndHashTag(QuickRecommendReq req, Long cursorId, String sort, Pageable pageable){
+        JPAQuery<ReviewPost> query = queryFactory
+                .select(hashtagClassification.reviewPost)
+                .from(hashtagClassification)
+                .join(hashtagClassification.hashTag, hashTag)
+                .where(hashtagContainsAgeOrInterest(req), nextReviewId(cursorId, true))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        if (sort.equalsIgnoreCase("asc")) {
+            query.orderBy(reviewPost.id.asc());
+        } else {
+            query.orderBy(reviewPost.id.desc());
+        }
+
+        List<ReviewPost> results = query.fetch();
+
+        JPAQuery<Long> count = queryFactory
+                .select(hashtagClassification.count())
+                .from(hashtagClassification)
+                .where(hashtagContainsAgeOrInterest(req), nextReviewId(cursorId, false))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize());
+
+        return PageableExecutionUtils.getPage(results, pageable, count::fetchOne);
+    }
+
+
+    private BooleanExpression hashtagContainsAgeOrInterest(QuickRecommendReq req) {
+        if (req == null) {
+            return null;
+        }
+
+        BooleanExpression ageCondition = ageRangeCondition(req.ageTag());
+        BooleanExpression interestCondition = hashTag.name.containsIgnoreCase(req.interestTag());
+
+        QHashtagClassification subHashtagClassification = new QHashtagClassification("subHashtagClassification");
+
+        JPQLQuery<Long> subQuery = JPAExpressions
+                .select(subHashtagClassification.reviewPost.id)
+                .from(subHashtagClassification)
+                .join(subHashtagClassification.hashTag, hashTag)
+                .where(ageCondition.or(interestCondition))
+                .groupBy(subHashtagClassification.reviewPost.id)
+                .having(subHashtagClassification.count().goe(1L)); // 수정된 부분
+
+        return hashtagClassification.reviewPost.id.in(subQuery);
+    }
+
+
+
     private BooleanExpression hashtagContains(String keyword) {
         if (keyword == null || keyword.isEmpty()) {
             return null;
         }
         return hashtagClassification.hashTag.name.containsIgnoreCase(keyword);
+    }
+
+    private BooleanExpression ageRangeCondition(String ageTag) {
+        if (ageTag == null || ageTag.isEmpty()) {
+            return null;
+        }
+
+        int midAge;
+        if (ageTag.contains("10대")) {
+            midAge = 15;
+        } else if (ageTag.contains("20대")) {
+            midAge = 25;
+        } else if (ageTag.contains("30대")) {
+            midAge = 35;
+        } else if (ageTag.contains("40대")) {
+            midAge = 45;
+        } else if (ageTag.contains("50대")) {
+            midAge = 55;
+        } else if (ageTag.contains("60대")) {
+            midAge = 65;
+        } else {
+            return hashTag.name.containsIgnoreCase(ageTag);
+        }
+
+        if (ageTag.contains("초반")) {
+            return hashTag.name.in(getAgeRange(midAge - 3));
+        } else if (ageTag.contains("중반")) {
+            return hashTag.name.in(getAgeRange(midAge));
+        } else if (ageTag.contains("후반")) {
+            return hashTag.name.in(getAgeRange(midAge + 3));
+        } else {
+            return hashTag.name.containsIgnoreCase(ageTag);
+        }
+    }
+
+    private List<String> getAgeRange(int midAge) {
+        return List.of(
+                (midAge - 5) + "살",
+                (midAge - 4) + "살",
+                (midAge - 3) + "살",
+                (midAge - 2) + "살",
+                (midAge - 1) + "살",
+                midAge + "살",
+                (midAge + 1) + "살",
+                (midAge + 2) + "살",
+                (midAge + 3) + "살",
+                (midAge + 4) + "살",
+                (midAge + 5) + "살",
+                (midAge/10)*10 +"대"
+        );
     }
 
     private BooleanExpression nextReviewId(Long cursorId, boolean asc) {

--- a/src/main/java/towssome/server/service/HashtagClassificationService.java
+++ b/src/main/java/towssome/server/service/HashtagClassificationService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import towssome.server.dto.CursorResult;
 import towssome.server.dto.PhotoInPost;
+import towssome.server.dto.QuickRecommendReq;
 import towssome.server.dto.ReviewSimpleRes;
 import towssome.server.entity.ReviewPost;
 import towssome.server.repository.HashtagClassificationRepository;
@@ -28,7 +29,8 @@ public class HashtagClassificationService{
         return getReviewSimpleResCursorResult(reviewSimpleRes, reviewPosts);
     }
 
-    private CursorResult<ReviewSimpleRes> getReviewSimpleResCursorResult(List<ReviewSimpleRes> reviewSimpleRes, Page<ReviewPost> reviewPosts) {
+    private CursorResult<ReviewSimpleRes> getReviewSimpleResCursorResult(List<ReviewSimpleRes> reviewSimpleRes,
+                                                                         Page<ReviewPost> reviewPosts) {
         Long cursorId;
         for(ReviewPost review : reviewPosts) {
             List<PhotoInPost> bodyPhotos = photoService.getPhotoS3Path(review);
@@ -65,4 +67,19 @@ public class HashtagClassificationService{
     public Object getAllHashtags() {
         return hashtagClassificationRepository.findAll();
     }
+
+
+    public CursorResult<ReviewSimpleRes> getRecommendPageByHashtag(QuickRecommendReq req, Long cursorId, String sort, Pageable page) {
+        List<ReviewSimpleRes> reviewSimpleRes = new ArrayList<>();
+
+        final Page<ReviewPost> reviewPosts = getRecommendReviewByHashtag(req, cursorId, sort, page);
+        return getReviewSimpleResCursorResult(reviewSimpleRes, reviewPosts);
+    }
+    public Page<ReviewPost> getRecommendReviewByHashtag(QuickRecommendReq req, Long cursorId, String sort, Pageable page){
+        return cursorId == null ?
+                hashtagClassificationRepository.findFirstRecommendPageByHashtag(req, sort, page):
+                hashtagClassificationRepository.findRecommendPageByCursorIdAndHashTag(req, cursorId, sort, page);
+    }
+
+
 }


### PR DESCRIPTION
매우매우 단순한 빠른 추천하기 구현했습니다.

알기로는 아직 태그가 나이랑, 관심사 밖에 없어서
예시로 나이는 "20대 중반"이라고 입력하면 25살 기준으로 +-5 범위의 나이 해시태그, 20대 해시태그에 해당되는 게시물이 추천되고,
관심사는 해당 단어가 포함되는 해시태그 모두가 추천범위에 들어갑니다.
카테고리는 확실하지 않아서 포함은 안해놓았습니다.

나이&관심사 모두 만족, 관심사만 만족, 나이만 만족 모두가 추천범위이고 우선순위도 해당 순서지만,
여러가지 시도해보았지만 무한스크롤로 잘 되지 않아서 일단은 우선순위 없이 reviewID로 정렬됩니다.