### PR TITLE
프로필 랭크 API + 회원가입 시 프로필 태그 저장 로직 수정

### DIFF
--- a/src/main/java/towssome/server/controller/HashtagController.java
+++ b/src/main/java/towssome/server/controller/HashtagController.java
@@ -85,4 +85,10 @@ public class HashtagController {
                 result.hasNext()
         );
     }
+
+    @GetMapping("/rank")
+    public List<HashtagRes> getHashtagRank(){
+
+        return hashtagService.getHashtagRank();
+    }
 }

--- a/src/main/java/towssome/server/dto/ReviewPostReq.java
+++ b/src/main/java/towssome/server/dto/ReviewPostReq.java
@@ -17,4 +17,5 @@ public record ReviewPostReq(
         @Schema(description = "리뷰 타입, 반드시 GIVEN or RECEIVED 둘 중 하나일 것")
         String reviewType
 ) {
+
 }

--- a/src/main/java/towssome/server/jwt/JoinDTO.java
+++ b/src/main/java/towssome/server/jwt/JoinDTO.java
@@ -6,6 +6,6 @@ public record JoinDTO(
         String username,
         String password,
         String nickname,
-        List<Long> profileTagIds
+        List<String> profileTagNames
 ) {
 }

--- a/src/main/java/towssome/server/jwt/JoinService.java
+++ b/src/main/java/towssome/server/jwt/JoinService.java
@@ -1,7 +1,6 @@
 package towssome.server.jwt;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +13,7 @@ import towssome.server.service.PhotoService;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -83,9 +83,25 @@ public class JoinService {
         categoryRepository.save(category);
 
         //프로필태그 생성
+        profileTageSave(joinDTO.profileTagNames(),member);
+
+        return member;
+    }
+
+    private void profileTageSave(List<String> list, Member member) {
+
         ArrayList<HashTag> hashTags = new ArrayList<>();
-        for (Long profileTagId : joinDTO.profileTagIds()) {
-            hashTags.add(hashTagRepository.findById(profileTagId).orElseThrow());
+
+        for (String name : list) {
+            if (hashTagRepository.existsByName(name)) {
+                hashTags.add(hashTagRepository.findByName(name));
+            }else{
+                HashTag save = hashTagRepository.save(new HashTag(
+                        name,
+                        0L
+                ));
+                hashTags.add(save);
+            }
         }
 
         for (HashTag hashTag : hashTags) {
@@ -95,7 +111,6 @@ public class JoinService {
             ));
         }
 
-        return member;
     }
 
 

--- a/src/main/java/towssome/server/jwt/LoginFilter.java
+++ b/src/main/java/towssome/server/jwt/LoginFilter.java
@@ -113,7 +113,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         Cookie cookie = new Cookie(key, value);
         cookie.setMaxAge(24*60*60);
-        //cookie.setSecure(true); //https 설정 시
+        cookie.setSecure(false); //https 설정 시
         //cookie.setPath("/");
         cookie.setHttpOnly(true);
 

--- a/src/main/java/towssome/server/repository/HashTagRepository.java
+++ b/src/main/java/towssome/server/repository/HashTagRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import towssome.server.entity.HashTag;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface HashTagRepository extends JpaRepository<HashTag,Long>, HashTagRepositoryCustom {
 
@@ -11,5 +12,6 @@ public interface HashTagRepository extends JpaRepository<HashTag,Long>, HashTagR
 
     HashTag findByName(String name);
 
+    Optional<HashTag> findHashTagByName(String name);
 
 }

--- a/src/main/java/towssome/server/repository/HashTagRepositoryCustom.java
+++ b/src/main/java/towssome/server/repository/HashTagRepositoryCustom.java
@@ -9,4 +9,6 @@ public interface HashTagRepositoryCustom {
 
     CursorResult<HashTag> searchHashtag(String name, int page, int size);
 
+    List<HashTag> getHashtagRank();
+
 }

--- a/src/main/java/towssome/server/repository/HashTagRepositoryImpl.java
+++ b/src/main/java/towssome/server/repository/HashTagRepositoryImpl.java
@@ -36,4 +36,13 @@ public class HashTagRepositoryImpl implements HashTagRepositoryCustom{
                 hasNext
         );
     }
+
+    @Override
+    public List<HashTag> getHashtagRank() {
+        return queryFactory
+                .selectFrom(hashTag)
+                .orderBy(hashTag.count.desc())
+                .limit(15)
+                .fetch();
+    }
 }

--- a/src/main/java/towssome/server/service/HashtagService.java
+++ b/src/main/java/towssome/server/service/HashtagService.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import towssome.server.dto.CursorResult;
+import towssome.server.dto.HashtagRes;
 import towssome.server.entity.HashTag;
 import towssome.server.entity.HashtagClassification;
 import towssome.server.entity.ReviewPost;
@@ -164,5 +165,22 @@ public class HashtagService {
     public CursorResult<HashTag> searchHashtag(String name, int page, int size) {
         return hashtagRepository.searchHashtag(name, page, size);
     }
+
+    public List<HashtagRes> getHashtagRank() {
+        List<HashTag> hashtagRank = hashtagRepository.getHashtagRank();
+
+        ArrayList<HashtagRes> result = new ArrayList<>();
+
+        for (HashTag hashTag : hashtagRank) {
+            result.add(new HashtagRes(
+                    hashTag.getId(),
+                    hashTag.getName()
+            ));
+        }
+
+        return result;
+    }
+
+
 
 }


### PR DESCRIPTION
#86 
회원가입 시 프로필 태그를 id가 아닌 string 형식으로 받게 했습니다. 
저장되지 않은 프로필 태그는 새로 저장됩니다.
/hashtag/rank API로 count수가 높은 해시태그 15개를 반환합니다