### PR TITLE
리뷰글 삭제 시 외래키 참조 문제 해결 + 로그인 시 username과 nickname도 제공하도록 설정

### DIFF
--- a/src/main/java/towssome/server/entity/ReviewPost.java
+++ b/src/main/java/towssome/server/entity/ReviewPost.java
@@ -5,6 +5,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import towssome.server.enumrated.ReviewType;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor
@@ -31,6 +34,15 @@ public class ReviewPost extends BaseEntity{
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @OneToMany(mappedBy = "reviewPost", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BookMark> bookMarks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "reviewPost", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ViewLike> viewLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "reviewPost", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
     public ReviewPost(String body, int price, ReviewType reviewType, String whereBuy, int starPoint, String category, Member member) {
         this.body = body;
         this.price = price;
@@ -45,5 +57,29 @@ public class ReviewPost extends BaseEntity{
         this.body = body;
         this.price = price;
         this.member = member;
+    }
+
+    public void addBookMarks(BookMark bookMark) {
+        bookMarks.add(bookMark);
+    }
+
+    public void removeBookMarks(BookMark bookMark) {
+        bookMarks.remove(bookMark);
+    }
+
+    public void addViewLikes(ViewLike viewLike) {
+        viewLikes.add(viewLike);
+    }
+
+    public void removeViewLikes(ViewLike viewLike) {
+        viewLikes.remove(viewLike);
+    }
+
+    public void addComments(Comment comment) {
+        comments.add(comment);
+    }
+
+    public void removeComments(Comment comment) {
+        comments.remove(comment);
     }
 }

--- a/src/main/java/towssome/server/jwt/LoginFilter.java
+++ b/src/main/java/towssome/server/jwt/LoginFilter.java
@@ -98,7 +98,12 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         // JSON 형식으로 반환
         PrintWriter out = response.getWriter();
-        out.print("{\"access\":\"" + access + "\", \"refresh\":\"" + refresh + "\", \"memberId\":" + member.getId() + "}");
+        out.print("{\"access\":\"" + access +
+                "\", \"refresh\":\"" + refresh +
+                "\", \"memberId\":" + member.getId() +
+                        ", \"username\":\"" + member.getUsername() +
+                        "\", \"nickname\":\"" + member.getNickName() +
+                "\"}");
         out.flush();
 
         response.setStatus(HttpStatus.OK.value());

--- a/src/main/java/towssome/server/repository/ViewLikeRepository.java
+++ b/src/main/java/towssome/server/repository/ViewLikeRepository.java
@@ -5,8 +5,11 @@ import towssome.server.entity.Member;
 import towssome.server.entity.ReviewPost;
 import towssome.server.entity.ViewLike;
 
+import java.util.List;
+
 
 public interface ViewLikeRepository extends JpaRepository<ViewLike,Long> {
     ViewLike findByReviewPostIdAndMemberId(Long reviewId, Long memberId);
     ViewLike findByReviewPostAndMember(ReviewPost reviewPost, Member member);
+    List<ViewLike> findAllByReviewPost(ReviewPost reviewPost);
 }

--- a/src/main/java/towssome/server/service/BookMarkService.java
+++ b/src/main/java/towssome/server/service/BookMarkService.java
@@ -126,6 +126,7 @@ public class BookMarkService {
                 category,
                 reviewPost
         );
+        reviewPost.addBookMarks(bookMark);
         return bookMarkRepository.save(bookMark);
     }
 
@@ -153,6 +154,8 @@ public class BookMarkService {
      * @param bookMark
      */
     public void deleteBookMark(BookMark bookMark) {
+        ReviewPost reviewPost = bookMark.getReviewPost();
+        reviewPost.removeBookMarks(bookMark);
         bookMarkRepository.delete(bookMark);
     }
 

--- a/src/main/java/towssome/server/service/CommentService.java
+++ b/src/main/java/towssome/server/service/CommentService.java
@@ -42,6 +42,7 @@ public class CommentService {
         );
         Comment savedComment = commentRepository.save(comment);
         reviewPost.getMember().addRankPoint(5);
+        reviewPost.addComments(comment); // 일대다 연관관계 추가
         return savedComment;
     }
 
@@ -58,6 +59,7 @@ public class CommentService {
     @Transactional
     public void deleteComment(Comment comment) {
         comment.getMember().addRankPoint(-3);
+        comment.getReviewPost().removeComments(comment); //일대다 연관관계 삭제
         commentRepository.delete(comment);
     }
 

--- a/src/main/java/towssome/server/service/ReviewPostService.java
+++ b/src/main/java/towssome/server/service/ReviewPostService.java
@@ -130,6 +130,7 @@ public class ReviewPostService {
     public void deleteReview(ReviewPost review) {
         photoService.deletePhotos(review);
         hashtagService.deleteHashtagByReviewPost(review);
+        viewlikeService.deleteCascadeForReview(review);
         reviewPostRepository.delete(review);
     }
 

--- a/src/main/java/towssome/server/service/ViewlikeService.java
+++ b/src/main/java/towssome/server/service/ViewlikeService.java
@@ -42,12 +42,12 @@ public class ViewlikeService {
             );
             viewLikeRepository.save(viewLike);
             review.getMember().addRankPoint(1);//랭크포인트 추가
+            review.addViewLikes(viewLike);
         } else {
             viewLike = viewLikeRepository.findByReviewPostAndMember(review, member);
             viewLike.addViewAmount(); //조회수 추가
             review.getMember().addRankPoint(1); //랭크포인트 추가
         }
-
 
     }
 
@@ -154,5 +154,12 @@ public class ViewlikeService {
             ));
         }
         return new CursorResult<>(reviewPostRes, result.nextPageId(), result.hasNext());
+    }
+
+    //특정 리뷰에 대한 조회, 좋아요 전부 삭제
+    @Transactional
+    public void deleteCascadeForReview(ReviewPost review) {
+        List<ViewLike> byReviewPost = viewLikeRepository.findAllByReviewPost(review);
+        viewLikeRepository.deleteAllInBatch(byReviewPost);
     }
 }


### PR DESCRIPTION
리뷰글 id를 참조하는 외래키가 워낙 많다보니 @oneToMany를 불가피하게 되었습니다. 다만 이미 데이터베이스에 생성된 테이블들에는 orphanRemoval가 먹히지 않으니 추후 데이터베이스를 초기화 시킬 필요가 있습니다