### PR TITLE
ClusterEntity 수정

### DIFF
--- a/src/main/java/towssome/server/entity/Cluster.java
+++ b/src/main/java/towssome/server/entity/Cluster.java
@@ -9,13 +9,15 @@ public class Cluster extends BaseEntity{
     @Column(name = "cluster_id")
     private Long id;
 
+    @Column(name = "cluster_num")
+    private Long clusterNum;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "hashtag_id")
-    private HashTag hashTag;
-
+    private HashTag hashtag;
 
 }


### PR DESCRIPTION
아직 클러스터 개발 중인데, 마이그레이션을 해버려서 급하게 엔티티 수정했습니다.

같은 클러스터인지 구분하는 cluster_num 컬럼을 추가했는데, 해당 테이블의 hashtag_id는 사용하지 않을 것 같습니다. 일단 삭제는 추후에 정리해야 할 거 같습니다...!