### PR TITLE
캘린더 생성 시 기본 태그 6개 생성

### DIFF
--- a/src/main/java/towssome/server/advice/ServiceAdvice.java
+++ b/src/main/java/towssome/server/advice/ServiceAdvice.java
@@ -2,9 +2,9 @@ package towssome.server.advice;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import towssome.server.entity.HashTag;
-import towssome.server.entity.Member;
-import towssome.server.entity.ProfileTag;
+import towssome.server.entity.*;
+import towssome.server.repository.CalendarPersonalScheduleRepository;
+import towssome.server.repository.CalendarTagRepository;
 import towssome.server.repository.hashtag.HashTagRepository;
 import towssome.server.repository.ProfileTagRepository;
 
@@ -17,7 +17,8 @@ public class ServiceAdvice {
 
     private final HashTagRepository hashTagRepository;
     private final ProfileTagRepository profileTagRepository;
-
+    private final CalendarTagRepository calendarTagRepository;
+    private final CalendarPersonalScheduleRepository calendarPersonalScheduleRepository;
 
     public void storeHashtag(List<String> list, Member member) {
         ArrayList<HashTag> hashTags = new ArrayList<>();
@@ -42,6 +43,46 @@ public class ServiceAdvice {
         }
     }
 
+    //캘린더 생성 시 기본 태그 6개 생성
+    //n주년, 생일, OO데이, 데이트, 남친/여친 개인 일정
+    public void calendarInitialize(Calendar calendar) {
+        CalendarTag OOthAnniversary = new CalendarTag(
+                "n주년",
+                1,
+                calendar
+        );
+        CalendarTag birthday = new CalendarTag(
+                "생일",
+                2,
+                calendar
+        );
+        CalendarTag couplesHoliday = new CalendarTag(
+                "연인 기념일",
+                3,
+                calendar
+        );
+        CalendarTag date = new CalendarTag(
+                "데이트",
+                4,
+                calendar
+        );
+        calendarTagRepository.save(OOthAnniversary);
+        calendarTagRepository.save(birthday);
+        calendarTagRepository.save(couplesHoliday);
+        calendarTagRepository.save(date);
+        CalendarPersonalSchedule personalSchedule1 = new CalendarPersonalSchedule(
+                "남자친구 일정",
+                5,
+                calendar
+        );
+        CalendarPersonalSchedule personalSchedule2 = new CalendarPersonalSchedule(
+                "여자친구 일정",
+                5,
+                calendar
+        );
+        calendarPersonalScheduleRepository.save(personalSchedule1);
+        calendarPersonalScheduleRepository.save(personalSchedule2);
+    }
 
 
 }

--- a/src/main/java/towssome/server/controller/CalendarController.java
+++ b/src/main/java/towssome/server/controller/CalendarController.java
@@ -1,30 +1,9 @@
 package towssome.server.controller;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-import towssome.server.advice.ImageMetaDataAdvice;
-import towssome.server.advice.MemberAdvice;
-import towssome.server.advice.PhotoAdvice;
-import towssome.server.dto.*;
-import towssome.server.entity.CalendarComment;
-import towssome.server.entity.DateCourse;
-import towssome.server.entity.Member;
-import towssome.server.entity.Photo;
-import towssome.server.enumrated.PhotoType;
-import towssome.server.exception.BodyOverException;
-import towssome.server.exception.IllegalDateException;
-import towssome.server.service.CalendarService;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @Tag(name = "캘린더")
 @RestController
@@ -32,132 +11,10 @@ import java.util.List;
 @RequestMapping("/calendar")
 public class CalendarController {
 
-    private final CalendarService calendarService;
-    private final MemberAdvice memberAdvice;
-    private final ImageMetaDataAdvice imageMetaDataAdvice;
-    private final PhotoAdvice photoAdvice;
-
-    @Operation(summary = "캘린더 월별 정보 출력 API", description = "AT 필요")
-    @GetMapping("/month")
-    public CalendarExistInMonth getMonthInfo(
-            @RequestParam int year,
-            @RequestParam int month){
-
-        Member member = memberAdvice.findJwtMember();
-
-        return calendarService.calendarInMonth(new CalendarInMonthReq(year, month),member);
-    }
-
-    @Operation(summary = "캘린더 일별 코멘트 API", description = "해당 일자의 코멘트 리스트를 반환합니다, AT 필요")
-    @GetMapping("/comment")
-    public ListResultRes<List<CalendarCommentRes>> getComments(
-            @RequestParam int year,
-            @RequestParam int month,
-            @RequestParam int day){
-
-        Member member = memberAdvice.findJwtMember();
-
-        return new ListResultRes<>(
-                calendarService.findCalendarCommentInDay(new CalendarInDayReq(year,month,day),member)
-        );
-    }
-
-    @Operation(summary = "캘린더 코멘트 생성 API", description = "캘린더의 코멘트를 생성합니다, AT 필요")
-    @PostMapping("/comment/create")
-    public ResponseEntity<?> createComment(CreateCalendarCommentReq req){
-
-        Member member = memberAdvice.findJwtMember();
-        CalendarComment comment = calendarService.createComment(member, req);
-
-        return new ResponseEntity<>(new CreateRes(
-                comment.getId()
-        ),HttpStatus.OK);
-    }
-
-    @Operation(summary = "캘린더 코멘트 삭제 API", description = "해당 id의 코멘트를 삭제합니다")
-    @PostMapping("/comment/delete")
-    public ResponseEntity<?> deleteComment(IdReq req){
-
-        calendarService.deleteComment(req.id());
-
-        return new ResponseEntity<>(HttpStatus.OK);
-    }
-
-    @Operation(summary = "캘린더 코멘트 업데이트 API", description = "해당 id의 코멘트를 업데이트합니다")
-    @PostMapping("/comment/update")
-    public ResponseEntity<?> updateComment(CalendarCommentUpdateReq req){
-
-        calendarService.updateComment(req);
+    @GetMapping("/")
+    public ResponseEntity<?> getCalendarInfo(){
 
         return null;
-    }
-
-    @Operation(summary = "데이트코스 가져오기 API",
-            description = "요청한 날짜 사이의 데이트코스 리스트를 반환합니다, AT 필요",
-    parameters = {@Parameter(name = "start", description = "검색을 시작할 날짜, yyyy-MM-DD 형식으로 전송"),
-    @Parameter(name = "end", description = "검색 끝 날짜, yyyy-MM-DD 형식으로 전송")})
-    @GetMapping("/dateCource")
-    public ListResultRes<List<DateCourseRes>> getDateCourse(
-            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate start,
-            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate end){
-
-        if (start.isAfter(end)) {
-            throw new IllegalDateException("시작 날짜는 항상 끝 날짜 이전이어야 합니다");
-        }
-
-        Member author = memberAdvice.findJwtMember();
-
-        List<DateCourseRes> result = calendarService.getDateCourseListByDate(start, end, author);
-
-        return new ListResultRes<>(
-                result
-        );
-    }
-
-    @Operation(summary = "데이트코스 생성 API",
-            description = "날짜와 사진을 받아 데이트코스를 생성합니다, AT 필요, 본문은 100자 이내, 사진은 필수입니다")
-    @PostMapping("/dateCourse/create")
-    public ResponseEntity<?> createDateCourse(
-            @RequestPart CreateDateCourseReq req,
-            @RequestPart MultipartFile photo){
-
-        if (req.body().length() > 100) {
-            throw new BodyOverException("본문은 100자 이내여야 합니다");
-        }
-
-        Member author = memberAdvice.findJwtMember();
-
-        Photo savePhoto = photoAdvice.savePhoto(photo, PhotoType.DATE_COURSE);
-        GpsInformationDTO extract = imageMetaDataAdvice.extract(photo);
-        DateCourse dateCourse = calendarService.createDateCourse(req, savePhoto, author, extract);
-
-        return new ResponseEntity<>(new CreateRes(
-                dateCourse.getId()
-        ), HttpStatus.OK);
-    }
-
-    @Operation(summary = "데이트코스 삭제 API",
-    description = "id를 입력받아 데이트코스를 삭제합니다")
-    @PostMapping("/dateCourse/delete")
-    public ResponseEntity<?> deleteDateCourse(@RequestBody IdReq req){
-
-        calendarService.deleteDateCourse(req.id());
-
-        return new ResponseEntity<>(HttpStatus.OK);
-    }
-
-    @Operation(summary = "데이트코스 업데이트 API",
-            description = "수정할 본문을 100자 이내로 작성하여 업데이트합니다")
-    @PostMapping("/dateCourse/update")
-    public ResponseEntity<?> updateDateCourse(@RequestBody @Valid UpdateDateCourseReq req){
-
-        if (req.body().length() > 100) {
-            throw new BodyOverException("본문은 100자 이내여야 합니다");
-        }
-
-        calendarService.updateDateCourse(req);
-
-        return new ResponseEntity<>(HttpStatus.OK);
     }
 
 

--- a/src/main/java/towssome/server/entity/CalendarPersonalSchedule.java
+++ b/src/main/java/towssome/server/entity/CalendarPersonalSchedule.java
@@ -1,9 +1,6 @@
 package towssome.server.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -23,8 +20,12 @@ public class CalendarPersonalSchedule {
     private String name;
     private int color; // 컬러 번호
 
-    public CalendarPersonalSchedule(String name, int color) {
+    @ManyToOne
+    private Calendar calendar;
+
+    public CalendarPersonalSchedule(String name, int color, Calendar calendar) {
         this.name = name;
         this.color = color;
+        this.calendar = calendar;
     }
 }

--- a/src/main/java/towssome/server/entity/CalendarTag.java
+++ b/src/main/java/towssome/server/entity/CalendarTag.java
@@ -24,8 +24,9 @@ public class CalendarTag {
     @ManyToOne(fetch = FetchType.LAZY)
     private Calendar calendar;
 
-    public CalendarTag(String name, int color) {
+    public CalendarTag(String name, int color, Calendar calendar) {
         this.name = name;
         this.color = color;
+        this.calendar = calendar;
     }
 }

--- a/src/main/java/towssome/server/repository/CalendarPersonalScheduleRepository.java
+++ b/src/main/java/towssome/server/repository/CalendarPersonalScheduleRepository.java
@@ -1,0 +1,7 @@
+package towssome.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import towssome.server.entity.CalendarPersonalSchedule;
+
+public interface CalendarPersonalScheduleRepository extends JpaRepository<CalendarPersonalSchedule,Long> {
+}

--- a/src/main/java/towssome/server/repository/CalendarPostCommentRepository.java
+++ b/src/main/java/towssome/server/repository/CalendarPostCommentRepository.java
@@ -1,0 +1,7 @@
+package towssome.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import towssome.server.entity.CalendarPostComment;
+
+public interface CalendarPostCommentRepository extends JpaRepository<CalendarPostComment,Long> {
+}

--- a/src/main/java/towssome/server/repository/CalendarPostRepository.java
+++ b/src/main/java/towssome/server/repository/CalendarPostRepository.java
@@ -1,0 +1,7 @@
+package towssome.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import towssome.server.entity.CalendarPost;
+
+public interface CalendarPostRepository extends JpaRepository<CalendarPost,Long> {
+}

--- a/src/main/java/towssome/server/repository/CalendarScheduleRepository.java
+++ b/src/main/java/towssome/server/repository/CalendarScheduleRepository.java
@@ -1,0 +1,7 @@
+package towssome.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import towssome.server.entity.CalendarSchedule;
+
+public interface CalendarScheduleRepository extends JpaRepository<CalendarSchedule,Long> {
+}

--- a/src/main/java/towssome/server/repository/CalendarTagRepository.java
+++ b/src/main/java/towssome/server/repository/CalendarTagRepository.java
@@ -1,0 +1,8 @@
+package towssome.server.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import towssome.server.entity.CalendarTag;
+
+public interface CalendarTagRepository extends JpaRepository<CalendarTag,Long> {
+
+}

--- a/src/main/java/towssome/server/service/CalendarService.java
+++ b/src/main/java/towssome/server/service/CalendarService.java
@@ -1,211 +1,22 @@
 package towssome.server.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-import towssome.server.advice.ImageMetaDataAdvice;
-import towssome.server.advice.PhotoAdvice;
-import towssome.server.dto.*;
-import towssome.server.entity.*;
-import towssome.server.enumrated.PhotoType;
-import towssome.server.exception.NotFoundCalendarException;
-import towssome.server.exception.NotFoundCommentException;
-import towssome.server.exception.NotFoundDateCourseException;
-import towssome.server.repository.date_course.DateCourseRepository;
-import towssome.server.repository.calendar_comment.CalendarCommentRepository;
-import towssome.server.repository.CalendarRepository;
-import towssome.server.repository.reviewpost.ReviewPostRepository;
-
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import towssome.server.repository.*;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class CalendarService {
 
-    private final CalendarCommentRepository calendarCommentRepository;
-    private final CalendarRepository calendarRepository;
-    private final ReviewPostRepository reviewPostRepository;
-    private final DateCourseRepository dateCourseRepository;
-    private final PhotoAdvice photoAdvice;
-    private final ImageMetaDataAdvice imageMetaDataAdvice;
-
-    public CalendarComment createComment(Member member, CreateCalendarCommentReq req) {
-
-        //캘린더는 연인 신청을 받으면 자동으로 생성
-        Calendar calendar = getCalendar(member);
-
-        return calendarCommentRepository.save(new CalendarComment(
-                member, req.body(), calendar, new RegistrationDate(req.year(), req.month(), req.day())
-        ));
-    }
-
-    // 캘린더 댓글 삭제
-    @Transactional
-    public void deleteComment(Long deleteId) {
-        calendarCommentRepository.delete(calendarCommentRepository.findById(deleteId).orElseThrow(
-                () -> new NotFoundCommentException("해당 코멘트를 찾지 못했습니다")
-        ));
-    }
-
-    /**
-     * 해당 멤버가 캘린더가 있으면 리뷰와 캘린더 코멘트, 데이트코스를 작성한 날짜를 반환합니다
-     * @param req
-     * @param member
-     * @return 리뷰, 캘린더 코멘트, 데이트코스 작성 날짜
-     */
-    public CalendarExistInMonth calendarInMonth(CalendarInMonthReq req, Member member) {
-        Calendar calendar = getCalendar(member);
-        List<Integer> commentList = calendarCommentRepository.findCommentsInCalendarOfMonth(req.year(), req.month(), calendar);
-        List<Integer> reviewList = reviewPostRepository.findReviewInCalendarOfMonth(req.year(), req.month(), calendar);
-        List<Integer> dateCourseList = dateCourseRepository.ExistDateCourseByDate(req, calendar);
-
-        return new CalendarExistInMonth(
-                reviewList,
-                commentList,
-                dateCourseList
-        );
-    }
-
-    /**
-     * 연,월,일을 입력받아 해당 날짜의 코멘트 리스트를 받아옵니다
-     * @param req
-     * @param member
-     * @return 코멘트 리스트
-     */
-    public List<CalendarCommentRes> findCalendarCommentInDay(CalendarInDayReq req, Member member) {
-        Calendar calendar = getCalendar(member);
-
-        List<CalendarComment> comments =
-                calendarCommentRepository.findCommentsByDay(
-                        LocalDate.of(req.year(), req.month(), req.day()),
-                        calendar);
-
-        ArrayList<CalendarCommentRes> result = new ArrayList<>();
-
-        for (CalendarComment comment : comments) {
-            result.add(new CalendarCommentRes(
-                    comment.getBody(),
-                    comment.getId(),
-                    comment.getCreateDate()
-            ));
-        }
-
-        return result;
-    }
-
-    //캘린더 코멘트 업데이트
-    @Transactional
-    public void updateComment(CalendarCommentUpdateReq req) {
-
-        CalendarComment comment = calendarCommentRepository.findById(req.id()).orElseThrow(
-                () -> new NotFoundCalendarException("해당 캘린더 코멘트가 없습니다!")
-        );
-
-        comment.update(req.body());
-    }
-
-    /**
-     * 사진과 날짜를 입력받아 데이트코스를 저장합니다. 1 데이트코스 = 1 사진
-     * @param req
-     * @param file
-     * @param member
-     * @return
-     */
-    public DateCourse createDateCourse(CreateDateCourseReq req, Photo photo, Member member, GpsInformationDTO extract) {
-        Calendar calendar = calendarRepository.findByAuth(member).orElseThrow(
-                () -> new NotFoundCalendarException("아직 캘린더가 없습니다")
-        );
-        DateCourse dateCourse = new DateCourse(
-                req.body(),
-                member,
-                calendar,
-                new GPS(
-                        extract.longitude() != null ? extract.longitude() : null,
-                        extract.latitude() != null ? extract.latitude() : null
-                ),
-                new RegistrationDate(
-                        req.year(),
-                        req.month(),
-                        req.day()
-                ),
-                photo
-        );
-
-        return dateCourseRepository.save(dateCourse);
-    }
-
-    //데이트코스 삭제
-    @Transactional
-    public void deleteDateCourse(Long id) {
-        DateCourse dateCourse = dateCourseRepository.findById(id).orElseThrow(
-                () -> new NotFoundDateCourseException("해당 데이트코스가 없습니다")
-        );
-        Photo photo = dateCourse.getPhoto();
-        dateCourseRepository.delete(dateCourse);
-        photoAdvice.deletePhoto(photo.getId());
-    }
-
-    /**
-     * 시작날짜와 끝 날짜를 받아 그 사이 날짜의 데이트코스 리스트 반환
-     * @param req
-     * @param member
-     * @return 날짜, 사진, 작성자 닉네임, 작성자 프로필사진
-     */
-    public List<DateCourseRes> getDateCourseListByDate(LocalDate start, LocalDate end, Member member) {
-        Calendar calendar = calendarRepository.findByAuth(member).orElseThrow(
-                () -> new NotFoundCalendarException("아직 캘린더가 없습니다")
-        );
-
-        DateCourseByDateReq req = new DateCourseByDateReq(
-                start.getYear(),
-                end.getYear(),
-                start.getMonthValue(),
-                end.getMonthValue(),
-                start.getDayOfMonth(),
-                end.getDayOfMonth()
-        );
-
-        List<DateCourse> dateCourseByDate = dateCourseRepository.findDateCourseByDate(req, calendar);
-        List<DateCourseRes> result = new ArrayList<>();
-
-        for (DateCourse item : dateCourseByDate) {
-            result.add(new DateCourseRes(
-                    item.getId(),
-                    item.getDate().getRegistrationYear(),
-                    item.getDate().getRegistrationMonth(),
-                    item.getDate().getRegistrationDay(),
-                    item.getGps() == null ? null : item.getGps().getLongitude(),
-                    item.getGps() == null? null : item.getGps().getLatitude(),
-                    item.getBody(),
-                    item.getPhoto().getS3Path(),
-                    item.getAuthor().getNickName(),
-                    item.getAuthor().getProfilePhoto() == null ? null : item.getAuthor().getProfilePhoto().getS3Path()
-            ));
-        }
-
-        return result;
-    }
-
-    @Transactional
-    public DateCourse updateDateCourse(UpdateDateCourseReq req) {
-        DateCourse dateCourse = dateCourseRepository.findById(req.id()).orElseThrow(
-                () -> new NotFoundDateCourseException("해당 데이트코스가 없습니다")
-        );
-        dateCourse.update(req.body());
-        return dateCourse;
-    }
+    private final CalendarPersonalScheduleRepository calendarPersonalScheduleRepository;
+    private final CalendarScheduleRepository calendarScheduleRepository;
+    private final CalendarTagRepository calendarTagRepository;
+    private final CalendarPostCommentRepository calendarPostCommentRepository;
+    private final CalendarPostRepository calendarPostRepository;
 
 
-    //해당 멤버의 캘린더 가져오기
-    private Calendar getCalendar(Member member) {
-        Calendar calendar = calendarRepository.findByAuth(member).orElseThrow(
-                () -> new NotFoundCalendarException("아직 캘린더가 생성되지 않았습니다")
-        );
-        return calendar;
-    }
+
 
 }

--- a/src/main/java/towssome/server/service/DeprecatedCalendarService.java
+++ b/src/main/java/towssome/server/service/DeprecatedCalendarService.java
@@ -1,0 +1,206 @@
+package towssome.server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import towssome.server.advice.PhotoAdvice;
+import towssome.server.dto.*;
+import towssome.server.entity.*;
+import towssome.server.exception.NotFoundCalendarException;
+import towssome.server.exception.NotFoundCommentException;
+import towssome.server.exception.NotFoundDateCourseException;
+import towssome.server.repository.date_course.DateCourseRepository;
+import towssome.server.repository.calendar_comment.CalendarCommentRepository;
+import towssome.server.repository.CalendarRepository;
+import towssome.server.repository.reviewpost.ReviewPostRepository;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DeprecatedCalendarService {
+
+    private final CalendarCommentRepository calendarCommentRepository;
+    private final CalendarRepository calendarRepository;
+    private final ReviewPostRepository reviewPostRepository;
+    private final DateCourseRepository dateCourseRepository;
+    private final PhotoAdvice photoAdvice;
+
+    public CalendarComment createComment(Member member, CreateCalendarCommentReq req) {
+
+        //캘린더는 연인 신청을 받으면 자동으로 생성
+        Calendar calendar = getCalendar(member);
+
+        return calendarCommentRepository.save(new CalendarComment(
+                member, req.body(), calendar, new RegistrationDate(req.year(), req.month(), req.day())
+        ));
+    }
+
+    // 캘린더 댓글 삭제
+    @Transactional
+    public void deleteComment(Long deleteId) {
+        calendarCommentRepository.delete(calendarCommentRepository.findById(deleteId).orElseThrow(
+                () -> new NotFoundCommentException("해당 코멘트를 찾지 못했습니다")
+        ));
+    }
+
+    /**
+     * 해당 멤버가 캘린더가 있으면 리뷰와 캘린더 코멘트, 데이트코스를 작성한 날짜를 반환합니다
+     * @param req
+     * @param member
+     * @return 리뷰, 캘린더 코멘트, 데이트코스 작성 날짜
+     */
+    public CalendarExistInMonth calendarInMonth(CalendarInMonthReq req, Member member) {
+        Calendar calendar = getCalendar(member);
+        List<Integer> commentList = calendarCommentRepository.findCommentsInCalendarOfMonth(req.year(), req.month(), calendar);
+        List<Integer> reviewList = reviewPostRepository.findReviewInCalendarOfMonth(req.year(), req.month(), calendar);
+        List<Integer> dateCourseList = dateCourseRepository.ExistDateCourseByDate(req, calendar);
+
+        return new CalendarExistInMonth(
+                reviewList,
+                commentList,
+                dateCourseList
+        );
+    }
+
+    /**
+     * 연,월,일을 입력받아 해당 날짜의 코멘트 리스트를 받아옵니다
+     * @param req
+     * @param member
+     * @return 코멘트 리스트
+     */
+    public List<CalendarCommentRes> findCalendarCommentInDay(CalendarInDayReq req, Member member) {
+        Calendar calendar = getCalendar(member);
+
+        List<CalendarComment> comments =
+                calendarCommentRepository.findCommentsByDay(
+                        LocalDate.of(req.year(), req.month(), req.day()),
+                        calendar);
+
+        ArrayList<CalendarCommentRes> result = new ArrayList<>();
+
+        for (CalendarComment comment : comments) {
+            result.add(new CalendarCommentRes(
+                    comment.getBody(),
+                    comment.getId(),
+                    comment.getCreateDate()
+            ));
+        }
+
+        return result;
+    }
+
+    //캘린더 코멘트 업데이트
+    @Transactional
+    public void updateComment(CalendarCommentUpdateReq req) {
+
+        CalendarComment comment = calendarCommentRepository.findById(req.id()).orElseThrow(
+                () -> new NotFoundCalendarException("해당 캘린더 코멘트가 없습니다!")
+        );
+
+        comment.update(req.body());
+    }
+
+    /**
+     * 사진과 날짜를 입력받아 데이트코스를 저장합니다. 1 데이트코스 = 1 사진
+     * @param req
+     * @param file
+     * @param member
+     * @return
+     */
+    public DateCourse createDateCourse(CreateDateCourseReq req, Photo photo, Member member, GpsInformationDTO extract) {
+        Calendar calendar = calendarRepository.findByAuth(member).orElseThrow(
+                () -> new NotFoundCalendarException("아직 캘린더가 없습니다")
+        );
+        DateCourse dateCourse = new DateCourse(
+                req.body(),
+                member,
+                calendar,
+                new GPS(
+                        extract.longitude() != null ? extract.longitude() : null,
+                        extract.latitude() != null ? extract.latitude() : null
+                ),
+                new RegistrationDate(
+                        req.year(),
+                        req.month(),
+                        req.day()
+                ),
+                photo
+        );
+
+        return dateCourseRepository.save(dateCourse);
+    }
+
+    //데이트코스 삭제
+    @Transactional
+    public void deleteDateCourse(Long id) {
+        DateCourse dateCourse = dateCourseRepository.findById(id).orElseThrow(
+                () -> new NotFoundDateCourseException("해당 데이트코스가 없습니다")
+        );
+        Photo photo = dateCourse.getPhoto();
+        dateCourseRepository.delete(dateCourse);
+        photoAdvice.deletePhoto(photo.getId());
+    }
+
+    /**
+     * 시작날짜와 끝 날짜를 받아 그 사이 날짜의 데이트코스 리스트 반환
+     * @param req
+     * @param member
+     * @return 날짜, 사진, 작성자 닉네임, 작성자 프로필사진
+     */
+    public List<DateCourseRes> getDateCourseListByDate(LocalDate start, LocalDate end, Member member) {
+        Calendar calendar = calendarRepository.findByAuth(member).orElseThrow(
+                () -> new NotFoundCalendarException("아직 캘린더가 없습니다")
+        );
+
+        DateCourseByDateReq req = new DateCourseByDateReq(
+                start.getYear(),
+                end.getYear(),
+                start.getMonthValue(),
+                end.getMonthValue(),
+                start.getDayOfMonth(),
+                end.getDayOfMonth()
+        );
+
+        List<DateCourse> dateCourseByDate = dateCourseRepository.findDateCourseByDate(req, calendar);
+        List<DateCourseRes> result = new ArrayList<>();
+
+        for (DateCourse item : dateCourseByDate) {
+            result.add(new DateCourseRes(
+                    item.getId(),
+                    item.getDate().getRegistrationYear(),
+                    item.getDate().getRegistrationMonth(),
+                    item.getDate().getRegistrationDay(),
+                    item.getGps() == null ? null : item.getGps().getLongitude(),
+                    item.getGps() == null? null : item.getGps().getLatitude(),
+                    item.getBody(),
+                    item.getPhoto().getS3Path(),
+                    item.getAuthor().getNickName(),
+                    item.getAuthor().getProfilePhoto() == null ? null : item.getAuthor().getProfilePhoto().getS3Path()
+            ));
+        }
+
+        return result;
+    }
+
+    @Transactional
+    public DateCourse updateDateCourse(UpdateDateCourseReq req) {
+        DateCourse dateCourse = dateCourseRepository.findById(req.id()).orElseThrow(
+                () -> new NotFoundDateCourseException("해당 데이트코스가 없습니다")
+        );
+        dateCourse.update(req.body());
+        return dateCourse;
+    }
+
+
+    //해당 멤버의 캘린더 가져오기
+    private Calendar getCalendar(Member member) {
+        Calendar calendar = calendarRepository.findByAuth(member).orElseThrow(
+                () -> new NotFoundCalendarException("아직 캘린더가 생성되지 않았습니다")
+        );
+        return calendar;
+    }
+
+}


### PR DESCRIPTION
- 이전에 미리 만들어둔 캘린더 서비스를 deprecate로 옮기고 연인 연동 시 캘린더에 기본 태그 6개가 생성되도록 수정